### PR TITLE
optimization flags

### DIFF
--- a/client/ws.ts
+++ b/client/ws.ts
@@ -2,13 +2,15 @@
 
 import * as pako from 'pako';
 
+const config = require('../config.json');
+
 const host = window.document.location.host.replace(/:.*/, '');
 const ws = new WebSocket('ws://' + host + ':4080');
 
 const callbacks: any = {};
 
 ws.onmessage = (event) => {
-  const inflated: any = pako.inflate(event.data, { to: 'string' });
+  const inflated = config.optimizations.compression ? pako.inflate(event.data, { to: 'string' }) : event.data;
   const result: Result = JSON.parse(inflated);
   callbacks.result && callbacks.result(result);
 }

--- a/config.json
+++ b/config.json
@@ -7,7 +7,7 @@
     "connection": {
       "database": "postgres",
       "host": "localhost",
-      "port": 5432 
+      "port": 5432
     }
   },
   "dimensions": [{
@@ -25,5 +25,11 @@
     "title": "Departure Delay",
     "range": [0, 100],
     "bins": 25
-  }]
+  }],
+  "optimizations": {
+    "startOnPageload": true,
+    "preload": true,
+    "compression": true,
+    "snapping": true
+  }
 }

--- a/server/index.ts
+++ b/server/index.ts
@@ -19,7 +19,8 @@ app.use(express.static(__dirname + '/../public'));
 
 wss.on('connection', (ws) => {
   const send = (obj) => {
-    ws.send(pako.deflate(JSON.stringify(obj), { to: 'string'}), (err) => {
+    const msg = config.optimizations.compression ? pako.deflate(JSON.stringify(obj), { to: 'string'}) : JSON.stringify(obj);
+    ws.send(msg, (err) => {
       if (err) {
         console.warn(err);
       }


### PR DESCRIPTION
So far the flags are:

* `startOnPageload`: do we want to start preloading before the user has hovered or interacted with a chart?
* `preload`: do we want to preload at all, or only fetch values on demand?
* `compression`: should the data sent over websockets be compressed
* `snapping`: should we snap to the nearest available value? (doesn't do anything right now, but the flag is there for when we need it)

What else? @domoritz 