### PR TITLE
don't change the active dimension until a user clicks on a chart. re #20

### DIFF
--- a/client/index.ts
+++ b/client/index.ts
@@ -35,7 +35,7 @@ connection.onOpen(() => {
 
   const handleMousemove = (dimension: Dimension) => {
     return () => {
-      if (brushing) {
+      if (brushing || dimension.name !== api.activeDimension) {
         return;
       }
 


### PR DESCRIPTION
Related to #20, as we discussed the other day, it probably makes more sense for now to not change the active dimension on hover.

This PR makes it so the active dimension won't be changed until the user actually clicks on a chart to start brushing (i.e. hovering on an inactive chart won't clear the cache).

