### PR TITLE
Enable ArrowDB constructor to take an ArrayBuffor or a URL

### DIFF
--- a/src/db/arrow.ts
+++ b/src/db/arrow.ts
@@ -14,13 +14,19 @@ export class ArrowDB<V extends string, D extends string>
 
   public readonly blocking: boolean = true;
 
-  public constructor(private readonly url: string) {}
+  public constructor(private readonly urlOrArrayBuffer: string | ArrayBuffer) {}
 
   private filterMaskIndex = new Map<string, BitSet>();
 
   public async initialize() {
-    const response = await fetch(this.url);
-    const buffer = await response.arrayBuffer();
+    let buffer;
+
+    if (typeof this.urlOrArrayBuffer === "string") {
+      const response = await fetch(this.urlOrArrayBuffer);
+      buffer =  await response.arrayBuffer();
+    } else {
+      buffer = this.urlOrArrayBuffer
+    }
 
     this.data = Table.from(new Uint8Array(buffer));
 

--- a/src/db/arrow.ts
+++ b/src/db/arrow.ts
@@ -19,11 +19,11 @@ export class ArrowDB<V extends string, D extends string>
   private filterMaskIndex = new Map<string, BitSet>();
 
   public async initialize() {
-    let buffer;
+    let buffer: ArrayBuffer;
 
     if (typeof this.urlOrArrayBuffer === "string") {
       const response = await fetch(this.urlOrArrayBuffer);
-      buffer =  await response.arrayBuffer();
+      buffer = await response.arrayBuffer();
     } else {
       buffer = this.urlOrArrayBuffer
     }


### PR DESCRIPTION
Our arrow API needs a bit of additional config on the fetch to handle auth, so I modified the ArrowDB constructor to optionally take a pre-fetched ArrayBuffer instead of a URL.

I'm not particularly wedded to this approach, but it's working for us. Happy to change as needed.