### PR TITLE
automatically determine extent if not specified

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 .cache
 .rpt2_cache*
 .vscode/tags
-/package-lock.json
 build
 data/.ipynb_checkpoints
 data/altair-data-*
@@ -10,7 +9,7 @@ gaia-mapd/app.scss
 gaia-mapd/index.html
 gaia-mapd/index.ts
 node_modules
-
 npm-debug.log*
+package-lock.json
 yarn-debug.log*
 yarn-error.log*

--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,8 @@ gaia-mapd/app.scss
 gaia-mapd/index.html
 gaia-mapd/index.ts
 node_modules
-yarn-error.log
+
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+/package-lock.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .cache
 .rpt2_cache*
 .vscode/tags
+/package-lock.json
 build
 data/.ipynb_checkpoints
 data/altair-data-*
@@ -13,4 +14,3 @@ node_modules
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
-/package-lock.json

--- a/src/api.ts
+++ b/src/api.ts
@@ -26,7 +26,7 @@ export interface Dimension<D> {
   title?: string;
 
   /** Initial domain for the dimension. */
-  extent: Interval<number>;
+  extent?: Interval<number>;
 
   /** D3 format specifier. If time is true, this has to be a D3 date format. Otherwise it should be a number format. */
   format: string;

--- a/src/api.ts
+++ b/src/api.ts
@@ -25,7 +25,7 @@ export interface Dimension<D> {
   /** A title for the dimension */
   title?: string;
 
-  /** Initial domain for the dimension. */
+  /** Initial domain for the dimension.  If it's not supplied, will be inferred from the extent of the data. */
   extent?: Interval<number>;
 
   /** D3 format specifier. If time is true, this has to be a D3 date format. Otherwise it should be a number format. */

--- a/src/app.ts
+++ b/src/app.ts
@@ -285,7 +285,7 @@ export class App<V extends string, D extends string> {
     } else if (view.type === "1D") {
       const binConfig = (view.dimension.time ? binTime : bin)(
         view.dimension.bins,
-        view.dimension.extent || this.db.getDimensionExtent(view.dimension)
+        view.dimension.extent || await this.db.getDimensionExtent(view.dimension)
       );
       view.dimension.binConfig = binConfig;
 
@@ -356,7 +356,7 @@ export class App<V extends string, D extends string> {
       for (const dimension of view.dimensions) {
         const binConfig = (dimension.time ? binTime : bin)(
           dimension.bins,
-          dimension.extent || this.db.getDimensionExtent(dimension)
+          dimension.extent || await this.db.getDimensionExtent(dimension)
         );
         dimension.binConfig = binConfig;
       }

--- a/src/app.ts
+++ b/src/app.ts
@@ -285,7 +285,7 @@ export class App<V extends string, D extends string> {
     } else if (view.type === "1D") {
       const binConfig = (view.dimension.time ? binTime : bin)(
         view.dimension.bins,
-        view.dimension.extent
+        view.dimension.extent || this.db.getDimensionExtent(view.dimension)
       );
       view.dimension.binConfig = binConfig;
 
@@ -356,7 +356,7 @@ export class App<V extends string, D extends string> {
       for (const dimension of view.dimensions) {
         const binConfig = (dimension.time ? binTime : bin)(
           dimension.bins,
-          dimension.extent
+          dimension.extent || this.db.getDimensionExtent(dimension)
         );
         dimension.binConfig = binConfig;
       }

--- a/src/db/arrow.ts
+++ b/src/db/arrow.ts
@@ -407,4 +407,23 @@ export class ArrowDB<V extends string, D extends string>
 
     return cubes;
   }
+
+  public getDimensionExtent(dimension: Dimension<D>): Interval<number> {
+
+    const column = this.data.getColumn(dimension.name)!;
+    let max = column.get(0);
+    let min = max;
+
+    for (let value of column) {
+      if (value > max) {
+        max = value;
+      }
+      else if (value < min) {
+        min = value;
+      }
+    }
+
+    return [min, max];
+  }
+
 }

--- a/src/db/db.ts
+++ b/src/db/db.ts
@@ -42,4 +42,6 @@ export interface DataBase<V extends string, D extends string> {
     views: Views<V, D>,
     brushes: Map<D, Interval<number>>
   ): Index<V>;
+
+  getDimensionExtent(dimension: Dimension<D>): Interval<number>;
 }

--- a/src/db/db.ts
+++ b/src/db/db.ts
@@ -43,5 +43,5 @@ export interface DataBase<V extends string, D extends string> {
     brushes: Map<D, Interval<number>>
   ): Index<V>;
 
-  getDimensionExtent(dimension: Dimension<D>): Interval<number>;
+  getDimensionExtent(dimension: Dimension<D>): Promise<Interval<number>> | Interval<number>;
 }

--- a/src/db/mapd.ts
+++ b/src/db/mapd.ts
@@ -540,7 +540,20 @@ export class MapDDB<V extends string, D extends string>
     });
 
     return cubes;
-
-    return cubes;
   }
+
+  public async getDimensionExtent(dimension: Dimension<D>): Promise<Interval<number>> {
+
+    const field = this.getName(dimension.name);
+    const result = await this.query(`
+    SELECT
+      MIN(${field}) AS _min, MAX(${field}) AS _max
+    FROM ${this.table}
+    `);
+
+    const { _min, _max } = result[0];
+
+    return [_min, _max];
+  }
+
 }


### PR DESCRIPTION
Fixes #101 

"tested" by removing extents from `flights/index.ts` and viewing the histograms.

(Also added some stuff to `.gitignore` for those of us still using npm)